### PR TITLE
Add markdownlint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,17 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Run markdownlint
+        run: npx markdownlint-cli README.md "rules/**/*.md"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for markdownlint

## Testing
- `npx markdownlint-cli README.md rules/**/*.md` *(fails: no network access)*